### PR TITLE
Fix for building with recent versions of miniupnp library.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1082,10 +1082,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
See this bitcoin pull request from August 2015:
https://github.com/bitcoin/bitcoin/commit/af9305a7e8a40014508fb66a22ae95e8afe142c6
